### PR TITLE
Enforced atomic Product.inventory updates

### DIFF
--- a/shopping/shop_app/models/receipt.py
+++ b/shopping/shop_app/models/receipt.py
@@ -1,6 +1,5 @@
 from django.db import models, IntegrityError, transaction
 from django.core.exceptions import ValidationError
-from django.utils.translation import gettext_lazy as _
 from .customer import Customer
 from .product import Product
 
@@ -10,7 +9,7 @@ class Receipt(models.Model):
 
   customer = models.ForeignKey(Customer, on_delete = models.CASCADE, blank = False)
   product = models.ForeignKey(Product, on_delete = models.CASCADE, blank = False)
-  quantity = models.SmallIntegerField(blank = False)
+  quantity = models.PositiveIntegerField(blank = False)
   total = models.DecimalField(max_digits = 8, decimal_places = 2, blank = True, editable = False)
   confirmation_code = models.CharField(max_length = 100, blank = True, editable = False)
 
@@ -18,36 +17,33 @@ class Receipt(models.Model):
   # https://docs.djangoproject.com/en/2.0/ref/models/querysets/#select-for-update
   def clean(self):
     """
-    override for custom validation
+    override to ensure a locked transaction for decrementing product inventory
 
     guarantees concurrency of product inventory using atomic transactions and the row-locking method select_for_update() 
     """
-    
+    super(Receipt, self).clean_fields()
+
+    if self.quantity == 0:
+      raise ValidationError({ 'quantity': 'Must enter a purchase quantity greater than zero' })
+
     try:
-      with transaction.atomic(): 
+      with transaction.atomic():
+        # locking the product row for inventory update
         product = Product.objects.select_for_update().get(pk = self.product.pk)
-        if product.inventory < self.quantity:
-          raise ValidationError({'quantity': 'tit'})
-        else:
-          product.inventory -= self.quantity
-          product.save()
+
+        if product.inventory == 0:
+          raise ValidationError({ 'quantity': 'This product is no longer available' })
+
+        product.inventory -= self.quantity
+        product.save()
     except (IntegrityError):
-      raise ValidationError({'quantity': _('The quantity %d requested is not available. Only %d of %s remain' % (self.quantity, self.product.inventory, self.product.name))})
+      raise ValidationError({ 'quantity': 'The quantity [%d] requested is not available. Only [%d] of %s remain' % (self.quantity, self.product.inventory, self.product.name) })
 
     self.total = self.product.cost * self.quantity
-    self.confirmation_code = self.generate_confirmation()
-
-  # full_clean() is not called by default in the Django model save() method
-  # call to trigger the self.clean() method and provide the above validation
-  # https://docs.djangoproject.com/en/2.0/ref/models/instances/#validating-objects
-  # https://docs.djangoproject.com/en/2.0/topics/db/models/#overriding-predefined-model-methods
-  def save(self, *args, **kwargs):
-    # self.full_clean()
-    self.clean()
-    return super().save(*args, **kwargs) # call Model save()
+    self.confirmation_code = self._generate_confirmation()
 
       
-  def generate_confirmation(self):
+  def _generate_confirmation(self):
     """
     returns a confirmation code of the format (spaces inserted for readability):
 


### PR DESCRIPTION
- Override the clean() method on Receipts (called during a form submission)
- validates the purchase quantity is non-zero

performs an atomic transaction for Product.inventory updates
- uses the select_for_update() method to lock the given product row
- validates that at the time of creating a receipt the product inventory is greater than zero
- decrements the product inventory before releasing the lock
- updates the receipt total and generates a confirmation code on completion